### PR TITLE
Feature kita ad items show

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -6,6 +6,7 @@ class Admin::ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   def edit

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,4 +3,12 @@ class Item < ApplicationRecord
   has_many   :order_details
   has_many   :cart_item
   has_one_attached :image
+  
+  
+  #税込み価格を表示するための記述です。
+  #add_tax_(消費税を計算したいカラム名)
+  def add_tax_price
+  (self.price * 1.10).round
+  end
+  
 end

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,2 +1,21 @@
-<h1>Admin::Items#show</h1>
-<p>Find me in app/views/admin/items/show.html.erb</p>
+<div>
+  <%= image_tag @item.get_image %>
+  <p>商品名：<%= @item.name %></p>
+  <p>商品説明：<%= @item.caption %></p>
+  <p>ジャンル：<%= @item.genre.id %></p>
+
+  <!-- モデルに記述したadd_tax_priceメソッドを使用して税込価格を表示 -->
+  <!-- (:dalimited)は数値を3桁区切りにしてくれる(ex:1,234円) -->
+  <p>税抜価格</br>(税込価格)</p>
+  ：<%= @item.price %>(<%= @item.add_tax_price.to_s(:dalimited) %>)円
+
+  <!-- もしステータスがtrueであれば販売中を返し、そうでなければ販売停止中を返す -->
+   <p>販売ステータス</p>
+   <% if @item.is_active == true %>
+      <%= @item.is_active_true, "販売中" %>
+    <% else %>
+      <%= @item.is_active_false, "販売停止中" %>
+    <% end %>
+    
+    <%= link_to "編集する", edit_admin_items_path(@item), class: "btn btn-sm btn-success" %>
+</div>


### PR DESCRIPTION
➀create後の遷移先にミスがあったため修正しました。
➁そもそも商品画像がないという状況がおこらない（商品画像はなきゃダメ）ため、
　 if image.attached?の部分を削除して修正しました。
③商品の詳細画面を作成しました。
④ジャンル一覧のパスを修正しないと動かなかったのでここだけresourcesに合わせてパス変更しました。

とりあえず機能の実装のみでレイアウトは手つけてません。
商品自体は４個ほど実際に登録してみました。